### PR TITLE
Added new steps, JSON Pointer {path} is any integer/float

### DIFF
--- a/src/zato/apitest/steps/json.py
+++ b/src/zato/apitest/steps/json.py
@@ -27,6 +27,13 @@ from jsonpointer import resolve_pointer as get_pointer, set_pointer as _set_poin
 from .. import util
 from .. import INVALID
 
+# Integer types for testing 'JSON Pointer {path} is any integer'
+try:
+    int_types = [int, long]
+except:
+    int_types = [int]     # python 3 doesn't have the long type
+
+
 # ################################################################################################################################
 
 def set_pointer(ctx, path, value):
@@ -134,7 +141,8 @@ def then_json_pointer_is_an_integer(ctx, path, value):
 @util.obtain_values
 def then_json_pointer_is_any_integer(ctx, path):
     actual = get_pointer(ctx.zato.response.data_impl, path)
-    assert type(actual) == int, 'Expected an integer in {}, got a `{}`'.format(path, type(actual))
+    assert any(map(lambda t: isinstance(actual, t), int_types)), \
+        'Expected an integer in {}, got a `{}`'.format(path, type(actual))
     return True
 
 @then('JSON Pointer "{path}" is a float "{value}"')
@@ -146,7 +154,8 @@ def then_json_pointer_is_a_float(ctx, path, value):
 @util.obtain_values
 def then_json_pointer_is_any_float(ctx, path):
     actual = get_pointer(ctx.zato.response.data_impl, path)
-    assert type(actual) == float, 'Expected a float in {}, got a `{}`'.format(path, type(actual))
+    assert isinstance(actual, float), \
+        'Expected a float in {}, got a `{}`'.format(path, type(actual))
     return True
 
 @then('JSON Pointer "{path}" is a list "{value}"')

--- a/src/zato/apitest/steps/json.py
+++ b/src/zato/apitest/steps/json.py
@@ -29,9 +29,9 @@ from .. import INVALID
 
 # Integer types for testing 'JSON Pointer {path} is any integer'
 try:
-    int_types = [int, long]
+    int_types = (int, long)
 except:
-    int_types = [int]     # python 3 doesn't have the long type
+    int_types = (int,)     # python 3 doesn't have the long type
 
 
 # ################################################################################################################################
@@ -141,7 +141,7 @@ def then_json_pointer_is_an_integer(ctx, path, value):
 @util.obtain_values
 def then_json_pointer_is_any_integer(ctx, path):
     actual = get_pointer(ctx.zato.response.data_impl, path)
-    assert any(map(lambda t: isinstance(actual, t), int_types)), \
+    assert isinstance(actual, int_types), \
         'Expected an integer in {}, got a `{}`'.format(path, type(actual))
     return True
 

--- a/src/zato/apitest/steps/json.py
+++ b/src/zato/apitest/steps/json.py
@@ -130,10 +130,24 @@ def then_json_pointer_is(ctx, path, value):
 def then_json_pointer_is_an_integer(ctx, path, value):
     return assert_value(ctx, path, value, int)
 
+@then('JSON Pointer "{path}" is any integer')
+@util.obtain_values
+def then_json_pointer_is_any_integer(ctx, path):
+    actual = get_pointer(ctx.zato.response.data_impl, path)
+    assert type(actual) == int, 'Expected an integer in {}, got a `{}`'.format(path, type(actual))
+    return True
+
 @then('JSON Pointer "{path}" is a float "{value}"')
 @util.obtain_values
 def then_json_pointer_is_a_float(ctx, path, value):
     return assert_value(ctx, path, value, float)
+
+@then('JSON Pointer "{path}" is any float')
+@util.obtain_values
+def then_json_pointer_is_any_float(ctx, path):
+    actual = get_pointer(ctx.zato.response.data_impl, path)
+    assert type(actual) == float, 'Expected a float in {}, got a `{}`'.format(path, type(actual))
+    return True
 
 @then('JSON Pointer "{path}" is a list "{value}"')
 @util.obtain_values

--- a/test/zato/apitest/steps/test_json.py
+++ b/test/zato/apitest/steps/test_json.py
@@ -144,11 +144,27 @@ class ThenTestCase(TestCase):
         self.ctx.zato.response.data_impl[path] = util.rand_int()
         self.assertRaises(AssertionError, json.then_json_pointer_is_an_integer, self.ctx, '/' + path, value)
 
+    def test_then_json_pointer_is_any_integer(self):
+        path = util.rand_string()
+        self.ctx.zato.response.data_impl[path] = util.rand_float()
+        self.assertRaises(AssertionError, json.then_json_pointer_is_any_integer, self.ctx, '/' + path)
+        self.ctx.zato.response.data_impl[path] = util.rand_int()
+        self.assertTrue(json.then_json_pointer_is_any_integer(self.ctx, '/' + path))
+
+
     def test_then_json_pointer_is_a_float(self):
         path = util.rand_string()
         value = util.rand_float()
         self.ctx.zato.response.data_impl[path] = util.rand_float()
         self.assertRaises(AssertionError, json.then_json_pointer_is_a_float, self.ctx, '/' + path, value)
+
+    def test_then_json_pointer_is_any_float(self):
+        path = util.rand_string()
+        self.ctx.zato.response.data_impl[path] = util.rand_int()
+        self.assertRaises(AssertionError, json.then_json_pointer_is_any_float, self.ctx, '/' + path)
+        self.ctx.zato.response.data_impl[path] = util.rand_float()
+        self.assertTrue(json.then_json_pointer_is_any_float(self.ctx, '/' + path))
+
 
     def test_then_json_pointer_is_a_list(self):
         path, value = util.rand_string(2)
@@ -185,7 +201,7 @@ class ThenTestCase(TestCase):
         path = util.rand_string()
         self.ctx.zato.response.data_impl[path] = True
         self.assertRaises(AssertionError, json.then_json_pointer_is_false, self.ctx, '/' + path)
-        
+
     def test_then_json_pointer_is_an_empty_list(self):
         path = util.rand_string()
         self.ctx.zato.response.data_impl[path] = util.rand_string(2)


### PR DESCRIPTION
I've added two new steps,  `JSON Pointer "{path}" is any integer` and `JSON Pointer "{path}" is any float` to test if a json pointer is an integer/float (any value).