### PR TITLE
Allow the json pointer option to receive a json

### DIFF
--- a/src/zato/apitest/steps/json.py
+++ b/src/zato/apitest/steps/json.py
@@ -23,6 +23,10 @@ from datadiff.tools import assert_equals
 # jsonpointer
 from jsonpointer import resolve_pointer as get_pointer, set_pointer as _set_pointer
 
+# json
+from .common import needs_json
+import json
+
 # Zato
 from .. import util
 from .. import INVALID
@@ -131,6 +135,18 @@ def assert_value(ctx, path, value, wrapper=None):
 @util.obtain_values
 def then_json_pointer_is(ctx, path, value):
     return assert_value(ctx, path, value)
+
+@then('JSON Pointer "{path}" is JSON "{value}"')
+@needs_json
+@util.obtain_values
+def then_json_pointer_is_json(ctx, path, value):
+    return assert_value(ctx, path, json.loads(value))
+
+@then('JSON Pointer "{path}" is JSON equal to that from "{value}"')
+@needs_json
+@util.obtain_values
+def then_json_pointer_is_json_equal_to_that_from(ctx, path, value):
+    return assert_value(ctx, path, json.loads(util.get_data(ctx, 'response', value)))
 
 @then('JSON Pointer "{path}" is an integer "{value}"')
 @util.obtain_values


### PR DESCRIPTION
I have not seen a way to compare a part of the response to a json, similar to: _response is equal to "{//json//}"_ but with a part of the request, like in JSON Pointer. I wrote a couple of functions of the type "JSON Pointer" following the idea of the 2 existing functions in steps/common.py: then_response_is_equal_to_that_from and then_response_is_equal_to.

I'm not sure @needs_json decorator is adecuated there.