### PR TITLE
Add form-encoded data format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,13 @@ Let's dissect directories that were created after running ```apitest init```:
     │       └── demo.json
     ├── steps
     │   └── steps.py
-    └── xml
+    ├── xml
+    │   ├── request
+    │   │   └── demo.xml
+    │   └── response
+    └── form
         ├── request
-        │   └── demo.xml
-        └── response
+           └── report.xls
 ```
 
 
@@ -123,6 +126,7 @@ Let's dissect directories that were created after running ```apitest init```:
 ```./features/steps/steps.py```    | Custom assertions go here.
 ```./features/xml/request/*```     | XML requests (including SOAP), if any, needed as input to APIs under tests.
 ```./features/xml/response/*```    | *(Currently not used, future versions will allow for comparing XML/SOAP responses directly)*
+```./features/form/request/*```    | Multipart-Encoded File uploads, if any to send in requests.
 
 Each set of related tests concerned with a particular feature is kept in its own *.feature file in /features.
 

--- a/docs/steps/step_given_file_upload_in_request.md
+++ b/docs/steps/step_given_file_upload_in_request.md
@@ -1,0 +1,29 @@
+
+Given Request file "{name}" is "{value}"
+=============================================================================================================
+
+Usage example
+-------------
+
+```
+Feature: zato-apitest docs
+
+Scenario: Given Request file "{name}" is "{value}"
+
+    Given address "http://apitest-demo.zato.io"
+    Given URL path "/demo/post"
+    Given HTTP method "POST"
+    Given format "FORM"
+    Given Request file "report" is "report.xls"
+
+    When the URL is invoked
+
+    Then status is "200"
+```
+
+Discussion
+----------
+
+Specifies the path to a file upload, relative to the ./features/form/request
+directory. This will send the request with http header Content-Type:
+multipart/form-data; boundary=XXX

--- a/docs/steps/step_given_form_encoded_data_in_request.md
+++ b/docs/steps/step_given_form_encoded_data_in_request.md
@@ -1,0 +1,30 @@
+
+Given Request param "{name}" is "{value}"
+=============================================================================================================
+
+Usage example
+-------------
+
+```
+Feature: zato-apitest docs
+
+Scenario: Given Request param "{name}" is "{value}"
+
+    Given address "http://apitest-demo.zato.io"
+    Given URL path "/demo/post"
+    Given HTTP method "POST"
+    Given format "FORM"
+    Given Request param "key1" is "value1"
+    Given Request param "key2" is "value2"
+
+    When the URL is invoked
+
+    Then status is "200"
+```
+
+Discussion
+----------
+
+This will send the request with http header 
+Content-Type: application/x-www-form-urlencoded
+

--- a/src/zato/apitest/steps/common.py
+++ b/src/zato/apitest/steps/common.py
@@ -265,6 +265,14 @@ def given_i_store_a_random_date_under_name(ctx, name, format):
 def then_context_is_cleaned_up(ctx):
     ctx.zato = util.new_context(ctx, None)
 
+@then('form is cleaned up')
+@util.obtain_values
+def then_form_is_cleaned_up(ctx):
+    if 'form' in ctx.zato.request:
+        del ctx.zato.request['form']
+    if 'files' in ctx.zato.request:
+        del ctx.zato.request['files']
+
 @then('status is "{expected_status}"')
 @util.obtain_values
 def then_status_is(ctx, expected_status):


### PR DESCRIPTION
Add support for form-encoded data and multipart-formdata file uploads.
Instead of using the RAW format, this commit adds native support for
posting form-encoded data, for example:

    Scenario: *** POST form-encoded data ***

        Given address "http://httpbin.org"
        Given URL path "/post"
        Given HTTP method "POST"
        Given Request format "FORM"
        Given Request param "key1" is "value1"
        Given Request param "key2" is "value2"
        Given Request file "myreport" is "report.xls"

The content-type for the request will be set to
application/x-www-form-urlencoded or if file upload exists will be set
to multipart/form-data.