### PR TITLE
Test runner improvements as discussed in issue #28.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ What it can do
 
 - Use [JSON Pointers] (https://zato.io/blog/posts/json-pointer-rfc-6901.html) or [XPath] (https://en.wikipedia.org/wiki/XPath)
   to set request's elements to strings, integers, floats, lists, random ones from a set of values, random strings, dates now/random/before/after/between.
-  
+
 - Check that JSON and XML elements, exist, don't exist,
   that an element is an integer, float, list, empty, non-empty, that it belongs to a list or doesn't.
 
@@ -36,12 +36,12 @@ What it can do
 
 - Check that HTTP headers are or are not of expected value, that a header exists or not, contains a value or not, is empty or not,
   starts with a value or not and ends with a value or not.
-  
+
 - Read configuration from environment and config files.
 
 - Store values extracted out of previous steps for use in subsequent steps, i.e. get a list of objects, pick ID of the first one
   and use this ID in later steps.
-  
+
 - Can be integrated with JUnit
 
 - Can be very easily extended in Python
@@ -86,6 +86,10 @@ Workflow
 3. Update tests
 4. Execute ```apitest run /path/to/tests/directory``` when you are done with updates
 5. Jump to 3.
+
+Note that when you give additional options to the ```apitest run``` command, they will be passed to the behave test runner,
+just like the options stored in the config.ini file. For instance, in a test run you can exclude and include only certain
+features using the ```-e``` option and ```-i``` options provided by the behave test runner.
 
 Tests and related resources
 ---------------------------
@@ -234,7 +238,7 @@ Scenario: Prepare data
     Given I store "Maria Garca" under "cust_name"
     Given request is "{}"
     Given JSON Pointer "/customer_id" in request is "$MYAPP_DEFAULT_CUSTOMER"
-    
+
     When the URL is invoked
 
     Then I store "/login" from response under "cust_login"

--- a/README.md
+++ b/README.md
@@ -98,9 +98,8 @@ Let's dissect directories that were created after running ```apitest init```:
 
 ```
 ~/mytests
-├── config
-│   └── behave.ini
 └── features
+    ├── config.ini
     ├── demo.feature
     ├── environment.py
     ├── json
@@ -119,7 +118,7 @@ Let's dissect directories that were created after running ```apitest init```:
 
  Path                              | Description
 ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------
-```./config/behave.ini```          | Low-level configuration that is passed to the underlying [behave] (https://pypi.python.org/pypi/behave) library as-is.
+```./features/config.ini```        | Low-level configuration that is passed to the underlying [behave] (https://pypi.python.org/pypi/behave) library as-is.
 ```./features/demo.feature```      | A set of tests for a single feature under consideration.
 ```./features/environment.py```    | Place to keep hooks invoked throughout a test case's life-cycle in.
 ```./features/json/request/*```    | JSON requests, if any, needed as input to APIs under tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ base32-crockford==0.2.0
 behave==1.2.4
 blist==1.3.6
 bunch==1.0.1
-click==1.1
+click==4.0
 configobj==5.0.5
 coverage==3.7.1
 datadiff==1.1.5

--- a/src/zato/apitest/cli.py
+++ b/src/zato/apitest/cli.py
@@ -46,10 +46,11 @@ def cli_init(ctx, path, prompt_run=True):
 def init(ctx, path):
     cli_init(ctx, path)
 
-@click.command()
+@click.command(context_settings=dict(allow_extra_args=True, ignore_unknown_options=True))
 @click.argument('path', type=click.Path(exists=True, file_okay=False, resolve_path=True))
-def run(path):
-    _run.handle(path)
+@click.pass_context
+def run(ctx, path):
+    _run.handle(path, ctx.args)
 
 @click.command()
 @click.argument('path', default=tempfile.gettempdir(), type=click.Path(exists=True, file_okay=False, resolve_path=True))

--- a/src/zato/apitest/run.py
+++ b/src/zato/apitest/run.py
@@ -21,13 +21,15 @@ from behave.runner import Runner
 # ConfigObj
 from configobj import ConfigObj
 
-def handle(path):
+def handle(path, args=None):
     file_conf = ConfigObj(os.path.join(path, 'features', 'config.ini'))
     try:
         behave_options = file_conf['behave']['options']
     except KeyError:
         raise RuntimeError("Behave config not found."
             " Are you running with the right path?")
+    if args:
+        behave_options += ' ' + ' '.join(args)
 
     conf = Configuration(behave_options)
     conf.paths = [os.path.join(path, 'features')]

--- a/src/zato/apitest/run.py
+++ b/src/zato/apitest/run.py
@@ -23,7 +23,11 @@ from configobj import ConfigObj
 
 def handle(path):
     file_conf = ConfigObj(os.path.join(path, 'features', 'config.ini'))
-    behave_options = file_conf['behave']['options']
+    try:
+        behave_options = file_conf['behave']['options']
+    except KeyError:
+        raise RuntimeError("Behave config not found."
+            " Are you running with the right path?")
 
     conf = Configuration(behave_options)
     conf.paths = [os.path.join(path, 'features')]


### PR DESCRIPTION
With this patch, additional command line options after `apitest run path` are sent to the behave test runner. This allows excluding or including only individual features.

Note that I had to update the click requirement to make this work.