### PR TITLE
zato-apitest should grow a new step to assign UUID values to JSON pointers

### DIFF
--- a/src/zato/apitest/steps/json.py
+++ b/src/zato/apitest/steps/json.py
@@ -31,6 +31,8 @@ import json
 from .. import util
 from .. import INVALID
 
+import uuid
+
 # Integer types for testing 'JSON Pointer {path} is any integer'
 try:
     int_types = (int, long)
@@ -52,6 +54,11 @@ def set_pointer(ctx, path, value):
 @util.obtain_values
 def given_json_pointer_in_request_is(ctx, path, value):
     set_pointer(ctx, path, value)
+
+@given('JSON Pointer "{path}" in request is a UUID')
+@util.obtain_values
+def given_json_pointer_in_request_is_a_uuid(ctx, path):
+    set_pointer(ctx, path, str(uuid.uuid4().hex))
 
 @given('JSON Pointer "{path}" in request is an integer "{value}"')
 @util.obtain_values

--- a/test/zato/apitest/steps/test_json.py
+++ b/test/zato/apitest/steps/test_json.py
@@ -23,6 +23,7 @@ from bunch import Bunch
 from zato.apitest import util
 from zato.apitest.steps import json, common
 
+import uuid
 # ###############################################################################################################################
 
 class GivenTestCase(TestCase):
@@ -60,6 +61,12 @@ class GivenTestCase(TestCase):
         json.given_json_pointer_in_request_is_a_random_string(self.ctx, '/' + path)
         self.assertEquals(len(self.ctx.zato.request.data_impl[path]), 33)
         self.assertEquals(self.ctx.zato.request.data_impl[path][0], 'a')
+
+    def test_given_json_pointer_in_request_is_a_uuid(self):
+        path = util.rand_string()
+        json.given_json_pointer_in_request_is_a_uuid(self.ctx, '/' + path)
+        self.assertIs(type(uuid.UUID(self.ctx.zato.request.data_impl[path], version=4)), uuid.UUID)
+
 
     def test_given_json_pointer_in_request_is_a_random_integer(self):
         path = util.rand_string()


### PR DESCRIPTION
So in an actual test it may look like:

Given JSON Pointer "/uid" in request is a UUID

And it will generate a pointer with uuid.uuid4().hex